### PR TITLE
feat: slope, HUD, layering, and lava drop fixes for Level 2-1

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@ function getGroundY(worldX) {
   // The slope is relative to the current screen so it looks consistent
   // throughout the level — the camera "climbs" with the player.
   const progress = Math.min(1, levelTimer / levelDuration); // 0→1 over the level
-  const slope = 0.22 + progress * 0.10; // rise/run ratio (~12°→18°, steepens over time)
+  const slope = 0.05 + progress * 0.10; // rise/run ratio — starts 5%, grows to 15%
 
   // screenX: position on screen (0 = left edge, W = right edge)
   const screenX = worldX - scrollOffset;
@@ -705,9 +705,9 @@ function spawnMoltenRock() {
     speed: speed,
     rotation: 0,
     rotationSpeed: -(0.018 + Math.random() * 0.012),
-    vy: -(3.5 + Math.random() * 3),
+    vy: 0,
     bounceY: 0,
-    bounceDamping: 0.55 + Math.random() * 0.2,
+    bounceDamping: 0,
     glowPhase: Math.random() * Math.PI * 2
   });
 }
@@ -952,8 +952,18 @@ function generateTrees() {
 // All lava objects use WORLD coordinates (worldX).
 // Screen position = worldX - scrollOffset
 function spawnLavaDrop() {
-  // All drops land in the rightmost 10% of screen
-  let screenTargetX = W * 0.9 + Math.random() * (W * 0.1 - 20);
+  let screenTargetX;
+  if (level === 4) {
+    // Level 2-1: drops only on rightmost 10%
+    screenTargetX = W * 0.9 + Math.random() * (W * 0.1 - 20);
+  } else {
+    // Levels 1-1 through 1-3: mostly left side, some right
+    if (Math.random() < 0.7) {
+      screenTargetX = 60 + Math.random() * (W * 0.5 - 60);
+    } else {
+      screenTargetX = W * 0.5 + Math.random() * (W * 0.5 - 40);
+    }
+  }
   const worldTargetX = screenTargetX + scrollOffset;
   warningMarkers.push({ worldX: worldTargetX, life: 60, maxLife: 60 });
   const savedScroll = scrollOffset;
@@ -1748,7 +1758,7 @@ function update() {
   const noDrops = level === 4 && levelProgress >= 0.5;
   const dropRate = level === 4
     ? Math.max(80, 140 - levelTimer * 0.007)
-    : Math.max(60, 180 - level * 8 - levelTimer * 0.005);
+    : Math.max(15, 60 - level * 8 - levelTimer * 0.005);
   const lavaChance = villageProgress > 0.5 ? Math.max(0, 1 - (villageProgress - 0.5) * 2) : 1;
   if (!noDrops && frameCount % Math.floor(dropRate) === 0 && Math.random() < lavaChance) {
     spawnLavaDrop();
@@ -2207,17 +2217,6 @@ function update() {
       mr.worldX -= mr.speed;
       mr.rotation += mr.rotationSpeed;
       mr.glowPhase += 0.1;
-      // Bounce physics — same as regular rocks
-      mr.vy += 0.3;
-      mr.bounceY += mr.vy;
-      if (mr.bounceY >= 0) {
-        mr.bounceY = 0;
-        if (Math.abs(mr.vy) > 0.8) {
-          mr.vy = -Math.abs(mr.vy) * mr.bounceDamping;
-        } else {
-          mr.vy = 0;
-        }
-      }
       // Remove if off screen left
       if (mr.worldX < scrollOffset - 100) {
         moltenRocks.splice(i, 1);
@@ -4513,7 +4512,7 @@ function _updateTreeConsts() {
   _treeSmSrcW = Math.floor(smallTreeImg.width  * (1 - smInset * 2));
   _treeSmSrcH = Math.floor(smallTreeImg.height * (1 - smInset * 2));
   const progress = Math.min(1, levelTimer / levelDuration);
-  const slope = 0.22 + progress * 0.10;
+  const slope = 0.05 + progress * 0.10;
   _treeSlopeAngle = Math.atan(slope);
   _treeConstsReady = true;
 }
@@ -5104,7 +5103,9 @@ function drawHUD() {
   ctx.fillStyle = '#33ccff';
   ctx.font = `bold 7px ${GAME_FONT}`;
   ctx.textAlign = 'left';
-  ctx.fillText(`LEVEL 1-${level} — NEO TOKYO`, 20, 38);
+  const hudLevel = level <= 3 ? `LEVEL 1-${level}` : `LEVEL ${Math.ceil(level/3)}-${((level-1)%3)+1}`;
+  const hudLocation = level <= 3 ? 'NEO TOKYO' : 'THE VOLCANO';
+  ctx.fillText(`${hudLevel} — ${hudLocation}`, 20, 38);
 
   // Score
   ctx.fillStyle = '#fff';
@@ -6090,7 +6091,8 @@ function drawTransition() {
   // Location name
   ctx.fillStyle = '#ffcc88';
   ctx.font = `12px ${GAME_FONT}`;
-  ctx.fillText('NEO TOKYO', W / 2, H / 2 + 20);
+  const locationName = level <= 3 ? 'NEO TOKYO' : 'THE VOLCANO';
+  ctx.fillText(locationName, W / 2, H / 2 + 20);
 
   ctx.globalAlpha = 1;
 }
@@ -6350,8 +6352,8 @@ function draw() {
       drawStreet();
     }
     if (level === 4) {
-      // ── LAYER 2: GROUND LAYER — mid trees, rocks, player ──
-      // Draw mid trees + rocks + player together
+      // ── LAYER 2: GROUND LAYER — lava pools, mid trees, rocks, player ──
+      drawLavaPools();
       for (const t of trees) {
         if (t.layer !== 'mid') continue;
         const sx = t.worldX - scrollOffset;
@@ -6371,7 +6373,7 @@ function draw() {
       drawPlayer();
       playerDrawnInDepth = true;
 
-      // ── LAYER 3: FRONT TREES (in front of player) ──
+      // ── LAYER 3: FRONT TREES (in front of player, rocks, and pools) ──
       for (const t of trees) {
         if (t.layer !== 'front') continue;
         const sx = t.worldX - scrollOffset;
@@ -6391,7 +6393,7 @@ function draw() {
 
     // Village environment draws on top of the shadow
     drawVillage();
-    drawLavaPools();
+    if (level !== 4) drawLavaPools(); // level 4 draws pools in ground layer
     drawVehicles();
     drawLavaDrops();
     drawExplosions();


### PR DESCRIPTION
- Ground slope starts at 5% and grows to 15% (was 22%-32%)
- HUD and transition screen show "LEVEL 2-1 — THE VOLCANO"
- Lava drops spread across full screen on levels 1-1 to 1-3 (70% left)
- Lava drops restricted to right 10% only on level 2-1
- Restore proper lava drop rate for levels 1-1 to 1-3
- Molten rocks no longer bounce (just roll)
- Lava pools, rocks, molten rocks all draw behind front-layer trees